### PR TITLE
Monitor router API key usage and balance

### DIFF
--- a/.github/workflows/usage-monitor.yml
+++ b/.github/workflows/usage-monitor.yml
@@ -1,0 +1,31 @@
+name: Usage Monitor
+
+on:
+  schedule:
+    # Hourly runs at minute 5. The script gates daily summary by hour to avoid duplicates.
+    - cron: '5 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run usage monitor
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          BALANCE_ALERT_THRESHOLD_USD: ${{ vars.BALANCE_ALERT_THRESHOLD_USD || '10' }}
+          DAILY_POST_UTC_HOUR: '16'
+        run: |
+          node usage-monitor/scripts/check-balance.mjs

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # usage-monitor
-A new project created on 2025-08-08
+
+See `usage-monitor/README.md` for setup and details.

--- a/usage-monitor/.github/workflows/usage-monitor.yml
+++ b/usage-monitor/.github/workflows/usage-monitor.yml
@@ -1,0 +1,46 @@
+name: Usage Monitor
+
+on:
+  schedule:
+    # Hourly runs at minute 5
+    - cron: '5 * * * *'
+    # Daily run at 16:05 UTC to emit the daily summary when balance >= threshold
+    - cron: '5 16 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run usage monitor
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          BALANCE_ALERT_THRESHOLD_USD: ${{ vars.BALANCE_ALERT_THRESHOLD_USD || '10' }}
+          DAILY_POST_UTC_HOUR: '16'
+          __USAGE_MONITOR_STATE_BASE64: ${{ secrets.USAGE_MONITOR_STATE_BASE64 }}
+        run: |
+          node usage-monitor/scripts/check-balance.mjs | tee monitor.log
+
+      - name: Save state for next run (optional)
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Extract the last JSON line and parse state_base64
+          STATE=$(tail -n 20 monitor.log | grep '"state_base64"' | tail -n 1 | sed -E 's/.*"state_base64":"([^"]+)".*/\1/')
+          if [ -n "$STATE" ]; then
+            echo "Captured state. You can store it as an organization or repo secret 'USAGE_MONITOR_STATE_BASE64' to prevent duplicate messages within the hour/day."
+            echo "state_base64=$STATE"
+          fi

--- a/usage-monitor/README.md
+++ b/usage-monitor/README.md
@@ -1,0 +1,39 @@
+# Usage Monitor (OpenRouter -> Slack)
+
+Monitors OpenRouter credits/usage and posts to Slack:
+
+- Under threshold (default $10): posts hourly
+- Otherwise: posts once per day at a fixed UTC hour (default 16:00)
+
+## Requirements
+
+- GitHub repository with Actions enabled
+- Secrets configured:
+  - `OPENROUTER_API_KEY`: your OpenRouter API key
+  - `SLACK_WEBHOOK_URL`: Slack Incoming Webhook URL
+- Optional:
+  - Repository variable `BALANCE_ALERT_THRESHOLD_USD` to override threshold
+
+## How it works
+
+- Reads credits from `GET /api/v1/credits` and key info from `GET /api/v1/key`
+- Computes remaining balance
+- If remaining < threshold, posts hourly and deduplicates by hour
+- Else, posts daily at the configured UTC hour and deduplicates by day
+
+## Local run
+
+```bash
+OPENROUTER_API_KEY=... \
+SLACK_WEBHOOK_URL=... \
+node usage-monitor/scripts/check-balance.mjs
+```
+
+Set `DAILY_POST_UTC_HOUR` and `BALANCE_ALERT_THRESHOLD_USD` to customize.
+
+## GitHub Actions
+
+Workflow file: `.github/workflows/usage-monitor.yml`
+- Runs hourly at minute 5
+- Also runs at 16:05 UTC for the daily summary
+- No persisted state is required; hourly runs handle alert cadence and a daily run posts the summary at the set hour.

--- a/usage-monitor/package.json
+++ b/usage-monitor/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "usage-monitor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "check": "node scripts/check-balance.mjs"
+  },
+  "dependencies": {}
+}

--- a/usage-monitor/scripts/check-balance.mjs
+++ b/usage-monitor/scripts/check-balance.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+// Usage Monitor for OpenRouter + Slack notifications
+// - Reads OPENROUTER_API_KEY and SLACK_WEBHOOK_URL from env
+// - Fetches credits and key usage from OpenRouter
+// - Decides whether to notify hourly (< $10 remaining) or daily (>= $10)
+// - Posts a message to Slack
+
+import process from 'node:process';
+
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || process.env.OPENROUTER_API_TOKEN;
+const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
+const BALANCE_ALERT_THRESHOLD_USD = parseFloat(process.env.BALANCE_ALERT_THRESHOLD_USD || '10');
+// Hour of day in UTC for daily summary, default 16:00 UTC
+const DAILY_POST_UTC_HOUR = parseInt(process.env.DAILY_POST_UTC_HOUR || '16', 10);
+
+if (!OPENROUTER_API_KEY) {
+  console.error('Missing OPENROUTER_API_KEY');
+  process.exit(2);
+}
+if (!SLACK_WEBHOOK_URL) {
+  console.error('Missing SLACK_WEBHOOK_URL');
+  process.exit(2);
+}
+
+/**
+ * Fetch JSON with simple retry
+ */
+async function fetchJson(url, init = {}, retries = 2) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const res = await fetch(url, init).catch((e) => ({ ok: false, status: 0, text: async () => String(e) }));
+    if (res && res.ok) return res.json();
+    if (attempt === retries) {
+      const body = res && typeof res.text === 'function' ? await res.text() : 'unknown error';
+      throw new Error(`Request failed ${url} status=${res?.status} body=${body}`);
+    }
+    await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
+  }
+}
+
+async function getCredits() {
+  // https://openrouter.ai/docs/api-reference/get-credits
+  const url = 'https://openrouter.ai/api/v1/credits';
+  const data = await fetchJson(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  // returns { data: { total_credits, total_usage } }
+  return data?.data;
+}
+
+async function getKeyInfo() {
+  // https://openrouter.ai/docs/api-reference/api-keys/get-current-api-key
+  const url = 'https://openrouter.ai/api/v1/key';
+  const data = await fetchJson(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  return data?.data; // { label, limit, usage, limit_remaining, is_free_tier, ... }
+}
+
+function formatUsd(n) {
+  const v = Number.isFinite(n) ? n : 0;
+  return `$${v.toFixed(2)}`;
+}
+
+function nowUtc() {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth();
+  const d = now.getUTCDate();
+  const h = now.getUTCHours();
+  const mi = now.getUTCMinutes();
+  return { now, y, m, d, h, mi };
+}
+
+function shouldSendDaily({ hourUtc }) {
+  return hourUtc === DAILY_POST_UTC_HOUR;
+}
+
+function hashDayKey(prefix = 'daily') {
+  const { y, m, d } = nowUtc();
+  return `${prefix}:${y}-${String(m + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+}
+
+// No persistent cache required; GitHub cron runs every hour. We dedupe by hour/day using time checks only.
+
+async function postToSlack({ text, fields = [], footer = '' }) {
+  const payload = {
+    text,
+    blocks: [
+      { type: 'section', text: { type: 'mrkdwn', text } },
+      ...(fields.length
+        ? [
+            {
+              type: 'section',
+              fields: fields.map((f) => ({ type: 'mrkdwn', text: `*${f.title}:* ${f.value}` })),
+            },
+          ]
+        : []),
+      { type: 'context', elements: [{ type: 'mrkdwn', text: footer || 'usage-monitor' }] },
+    ],
+  };
+
+  const res = await fetch(SLACK_WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(`Slack webhook failed: ${res.status} ${await res.text()}`);
+}
+
+async function main() {
+  const [{ total_credits = 0, total_usage = 0 } = {}, keyInfo = {}] = await Promise.all([
+    getCredits(),
+    getKeyInfo(),
+  ]);
+
+  const creditsPurchased = Number(total_credits) || 0;
+  const creditsUsed = Number(total_usage) || Number(keyInfo.usage) || 0;
+
+  // Remaining balance can be inferred from credits - usage OR keyInfo.limit_remaining when set
+  const remaining = Number.isFinite(keyInfo.limit_remaining)
+    ? Number(keyInfo.limit_remaining)
+    : Math.max(creditsPurchased - creditsUsed, 0);
+
+  const { h } = nowUtc();
+
+  const underThreshold = remaining < BALANCE_ALERT_THRESHOLD_USD;
+
+  let shouldNotify = false;
+  let cadence = 'daily';
+
+  if (underThreshold) {
+    // Post hourly when under threshold; cron runs hourly so every run at minute 5 will notify
+    cadence = 'hourly';
+    shouldNotify = true;
+  } else {
+    // Post once a day at configured hour; cron also triggers at that minute
+    cadence = 'daily';
+    if (shouldSendDaily({ hourUtc: h })) {
+      shouldNotify = true;
+    }
+  }
+
+  const fields = [
+    { title: 'Credits Purchased', value: formatUsd(creditsPurchased) },
+    { title: 'Credits Used', value: formatUsd(creditsUsed) },
+    { title: 'Balance Remaining', value: formatUsd(remaining) },
+    { title: 'Threshold', value: formatUsd(BALANCE_ALERT_THRESHOLD_USD) },
+    { title: 'Cadence', value: cadence },
+  ];
+
+  const text = underThreshold
+    ? `:rotating_light: OpenRouter balance low: ${formatUsd(remaining)} remaining`
+    : `:money_with_wings: OpenRouter balance: ${formatUsd(remaining)} remaining`;
+
+  if (shouldNotify) {
+    await postToSlack({ text, fields });
+    console.log('notified');
+  } else {
+    console.log('no-notify');
+  }
+
+  // Also emit a JSON line for logs/consumers
+  console.log(
+    JSON.stringify({
+      purchased: creditsPurchased,
+      used: creditsUsed,
+      remaining,
+      threshold: BALANCE_ALERT_THRESHOLD_USD,
+      cadence,
+      notified: shouldNotify
+    })
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Add an OpenRouter usage monitor that sends Slack notifications hourly for low balance and daily otherwise.

The GitHub Actions workflow runs hourly, and the script internally manages the daily notification cadence based on the current UTC hour, removing the need for persisted state.

---
<a href="https://cursor.com/background-agent?bcId=bc-35c9f4fe-c306-4c00-8642-5c6707f069ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35c9f4fe-c306-4c00-8642-5c6707f069ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

